### PR TITLE
deprecate USER env key

### DIFF
--- a/example.py
+++ b/example.py
@@ -6,7 +6,7 @@ import os
 from froeling import Froeling
 
 load_dotenv()
-username = os.getenv("USER")
+username = os.getenv("USERNAME")
 password = os.getenv("PASSWORD")
 token = os.getenv("TOKEN")
 


### PR DESCRIPTION
The env key `USER` is predefined in UNIX systems.
Some shells even do not allow it to be overwritten.

The patch replaces `USER` with `USERNAME` as env var.

I had thought about keeping `USER` as fallback like this:

```python
username = os.getenv("USERNAME") or os.getenv("USER")
```

But it's just an example, so I don't think changing it in a breaking way is a problem.